### PR TITLE
Add Vimeo and Twitter support

### DIFF
--- a/news/23.feature
+++ b/news/23.feature
@@ -1,0 +1,1 @@
+Added Differentiation between Youtube and Vimeo Videos in the Video-View, and added Twitter Module and Cookie Option if someone uses volto-social-blocks with this Addon @Molochem 

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -46,6 +46,12 @@ const Banner = (props) => {
   const [confirmGoogle, setConfirmGoogle] = useState(
     !!Number(cookies.confirm_google),
   );
+  const [confirmVimeo, setConfirmVimeo] = useState(
+    !!Number(cookies.confirm_vimeo),
+  );
+  const [confirmTwitter, setConfirmTwitter] = useState(
+    !!Number(cookies.confirm_twitter),
+  );
 
   const expiryDate = new Date();
   expiryDate.setMonth(expiryDate.getMonth() + 1);
@@ -81,6 +87,17 @@ const Banner = (props) => {
       setCookie('confirm_google', 1, options);
     } else {
       removeCookie('confirm_google', options);
+    }
+    if (confirmVimeo) {
+      setCookie('confirm_vimeo', 1, options);
+    } else {
+      removeCookie('confirm_vimeo', 1, options);
+    }
+
+    if (confirmTwitter) {
+      setCookie('confirm_twitter', 1, options);
+    } else {
+      removeCookie('confirm_twitter', 1, options);
     }
 
     setCookie('confirm_cookies', 1, options);
@@ -244,6 +261,26 @@ const Banner = (props) => {
                       label="Google"
                       onChange={() => setConfirmGoogle(!confirmGoogle)}
                       checked={confirmGoogle}
+                    />
+                  </Form.Field>
+                )}
+                {includes(modules, 'vimeo') && (
+                  <Form.Field>
+                    <Checkbox
+                      toggle
+                      label="Vimeo"
+                      onChange={() => setConfirmVimeo(!confirmVimeo)}
+                      checked={confirmVimeo}
+                    />
+                  </Form.Field>
+                )}
+                {includes(modules, 'twitter') && (
+                  <Form.Field>
+                    <Checkbox
+                      toggle
+                      label="Twitter"
+                      onChange={() => setConfirmTwitter(!confirmTwitter)}
+                      checked={confirmTwitter}
                     />
                   </Form.Field>
                 )}

--- a/src/components/Block/View.jsx
+++ b/src/components/Block/View.jsx
@@ -33,6 +33,12 @@ const View = (props) => {
   const [confirmGoogle, setConfirmGoogle] = useState(
     !!Number(cookies.confirm_google),
   );
+  const [confirmVimeo, setConfirmVimeo] = useState(
+    !!Number(cookies.confirm_vimeo),
+  );
+  const [confirmTwitter, setConfirmTwitter] = useState(
+    !!Number(cookies.confirm_twitter),
+  );
 
   const expiryDate = new Date();
   expiryDate.setMonth(expiryDate.getMonth() + 1);
@@ -70,9 +76,27 @@ const View = (props) => {
       removeCookie('confirm_google', options);
     }
 
+    if (confirmVimeo) {
+      setCookie('confirm_vimeo', 1, options);
+    } else {
+      removeCookie('confirm_vimeo', 1, options);
+    }
+
+    if (confirmTwitter) {
+      setCookie('confirm_twitter', 1, options);
+    } else {
+      removeCookie('confirm_twitter', 1, options);
+    }
+
     setCookie('confirm_cookies', 1, options);
     props.hideDSGVOBanner();
   };
+
+  //Save the selection on every switch in the settings
+  useEffect(() => {
+    confirmSelection();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confirmYoutube, confirmVimeo, confirmTwitter]);
 
   return (
     <>
@@ -122,6 +146,26 @@ const View = (props) => {
               label="Google"
               onChange={() => setConfirmGoogle(!confirmGoogle)}
               checked={confirmGoogle}
+            />
+          </Form.Field>
+        )}
+        {includes(modules, 'vimeo') && (
+          <Form.Field>
+            <Checkbox
+              toggle
+              label="Vimeo"
+              onChange={() => setConfirmVimeo(!confirmVimeo)}
+              checked={confirmVimeo}
+            />
+          </Form.Field>
+        )}
+        {includes(modules, 'twitter') && (
+          <Form.Field>
+            <Checkbox
+              toggle
+              label="Twitter"
+              onChange={() => setConfirmTwitter(!confirmTwitter)}
+              checked={confirmTwitter}
             />
           </Form.Field>
         )}

--- a/src/customizations/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/components/manage/Blocks/Video/View.jsx
@@ -9,7 +9,7 @@ import { Embed } from 'semantic-ui-react';
 import cx from 'classnames';
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
-import { IfConfirm } from '../../../../../components';
+import { default as IfConfirm } from '@kitconcept/volto-dsgvo-banner/components/IfConfirm/IfConfirm';
 
 /**
  * View video block class.
@@ -17,58 +17,109 @@ import { IfConfirm } from '../../../../../components';
  * @extends Component
  */
 const View = ({ data }) => (
-  <IfConfirm module="youtube">
-    <div
-      className={cx(
-        'block video align',
-        {
-          center: !Boolean(data.align),
-        },
-        data.align,
-      )}
-    >
-      {data.url && (
+  <>
+    {data.url.match('youtu') ? (
+      <>
+        <IfConfirm module="youtube">
+          <div
+            className={cx(
+              'block video align',
+              {
+                center: !Boolean(data.align),
+              },
+              data.align,
+            )}
+          >
+            {data.url && (
+              <div
+                className={cx('video-inner', {
+                  'full-width': data.align === 'full',
+                })}
+              >
+                {data.url.match('youtu') && (
+                  <>
+                    {data.url.match('list') ? (
+                      data.preview_image ? (
+                        <Embed
+                          url={`https://www.youtube.com/embed/videoseries?list=${
+                            data.url.match(/^.*\?list=(.*)$/)[1]
+                          }`}
+                          placeholder={
+                            isInternalURL(data.preview_image)
+                              ? `${flattenToAppURL(
+                                  data.preview_image,
+                                )}/@@images/image`
+                              : data.preview_image
+                          }
+                          defaultActive
+                          autoplay={false}
+                        />
+                      ) : (
+                        <Embed
+                          url={`https://www.youtube.com/embed/videoseries?list=${
+                            data.url.match(/^.*\?list=(.*)$/)[1]
+                          }`}
+                          icon="play"
+                          defaultActive
+                          autoplay={false}
+                        />
+                      )
+                    ) : data.preview_image ? (
+                      <Embed
+                        id={
+                          data.url.match(/.be\//)
+                            ? data.url.match(/^.*\.be\/(.*)/)[1]
+                            : data.url.match(/^.*\?v=(.*)$/)[1]
+                        }
+                        source="youtube"
+                        placeholder={
+                          isInternalURL(data.preview_image)
+                            ? `${flattenToAppURL(
+                                data.preview_image,
+                              )}/@@images/image`
+                            : data.preview_image
+                        }
+                        icon="play"
+                        autoplay={false}
+                      />
+                    ) : (
+                      <Embed
+                        id={
+                          data.url.match(/.be\//)
+                            ? data.url.match(/^.*\.be\/(.*)/)[1]
+                            : data.url.match(/^.*\?v=(.*)$/)[1]
+                        }
+                        source="youtube"
+                        icon="play"
+                        defaultActive
+                        autoplay={false}
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </IfConfirm>
+      </>
+    ) : (
+      <IfConfirm module="vimeo">
         <div
-          className={cx('video-inner', {
-            'full-width': data.align === 'full',
-          })}
-        >
-          {data.url.match('youtu') ? (
-            <>
-              {data.url.match('list') ? (
-                data.preview_image ? (
-                  <Embed
-                    url={`https://www.youtube.com/embed/videoseries?list=${
-                      data.url.match(/^.*\?list=(.*)$/)[1]
-                    }`}
-                    placeholder={
-                      isInternalURL(data.preview_image)
-                        ? `${flattenToAppURL(
-                            data.preview_image,
-                          )}/@@images/image`
-                        : data.preview_image
-                    }
-                    defaultActive
-                    autoplay={false}
-                  />
-                ) : (
-                  <Embed
-                    url={`https://www.youtube.com/embed/videoseries?list=${
-                      data.url.match(/^.*\?list=(.*)$/)[1]
-                    }`}
-                    icon="play"
-                    defaultActive
-                    autoplay={false}
-                  />
-                )
-              ) : data.preview_image ? (
+          className={cx(
+            'block video align',
+            {
+              center: !Boolean(data.align),
+            },
+            data.align,
+          )}
+        />
+        {data.url && (
+          <>
+            {data.url.match('vimeo') ? (
+              data.preview_image ? (
                 <Embed
-                  id={
-                    data.url.match(/.be\//)
-                      ? data.url.match(/^.*\.be\/(.*)/)[1]
-                      : data.url.match(/^.*\?v=(.*)$/)[1]
-                  }
-                  source="youtube"
+                  id={data.url.match(/^.*\.com\/(.*)/)[1]}
+                  source="vimeo"
                   placeholder={
                     isInternalURL(data.preview_image)
                       ? `${flattenToAppURL(data.preview_image)}/@@images/image`
@@ -79,77 +130,45 @@ const View = ({ data }) => (
                 />
               ) : (
                 <Embed
-                  id={
-                    data.url.match(/.be\//)
-                      ? data.url.match(/^.*\.be\/(.*)/)[1]
-                      : data.url.match(/^.*\?v=(.*)$/)[1]
-                  }
-                  source="youtube"
+                  id={data.url.match(/^.*\.com\/(.*)/)[1]}
+                  source="vimeo"
                   icon="play"
                   defaultActive
                   autoplay={false}
                 />
-              )}
-            </>
-          ) : (
-            <>
-              {data.url.match('vimeo') ? (
-                data.preview_image ? (
-                  <Embed
-                    id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                    source="vimeo"
-                    placeholder={
-                      isInternalURL(data.preview_image)
-                        ? `${flattenToAppURL(
-                            data.preview_image,
-                          )}/@@images/image`
-                        : data.preview_image
+              )
+            ) : (
+              <>
+                {data.url.match('.mp4') ? (
+                  // eslint-disable-next-line jsx-a11y/media-has-caption
+                  <video
+                    src={
+                      isInternalURL(data.url)
+                        ? `${flattenToAppURL(data.url)}/@@download/file`
+                        : data.url
                     }
-                    icon="play"
-                    autoplay={false}
+                    controls
+                    poster={
+                      data.preview_image
+                        ? isInternalURL(data.preview_image)
+                          ? `${flattenToAppURL(
+                              data.preview_image,
+                            )}/@@images/image`
+                          : data.preview_image
+                        : ''
+                    }
+                    type="video/mp4"
                   />
                 ) : (
-                  <Embed
-                    id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                    source="vimeo"
-                    icon="play"
-                    defaultActive
-                    autoplay={false}
-                  />
-                )
-              ) : (
-                <>
-                  {data.url.match('.mp4') ? (
-                    // eslint-disable-next-line jsx-a11y/media-has-caption
-                    <video
-                      src={
-                        isInternalURL(data.url)
-                          ? `${flattenToAppURL(data.url)}/@@download/file`
-                          : data.url
-                      }
-                      controls
-                      poster={
-                        data.preview_image
-                          ? isInternalURL(data.preview_image)
-                            ? `${flattenToAppURL(
-                                data.preview_image,
-                              )}/@@images/image`
-                            : data.preview_image
-                          : ''
-                      }
-                      type="video/mp4"
-                    />
-                  ) : (
-                    <div className="invalidVideoFormat" />
-                  )}
-                </>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  </IfConfirm>
+                  <div className="invalidVideoFormat" />
+                )}
+              </>
+            )}
+          </>
+        )}
+      </IfConfirm>
+    )}
+  </>
 );
 
 /**

--- a/src/customizations/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/components/manage/Blocks/Video/View.jsx
@@ -9,7 +9,7 @@ import { Embed } from 'semantic-ui-react';
 import cx from 'classnames';
 import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
 
-import { default as IfConfirm } from '@kitconcept/volto-dsgvo-banner/components/IfConfirm/IfConfirm';
+import IfConfirm from '@kitconcept/volto-dsgvo-banner/components/IfConfirm/IfConfirm';
 
 /**
  * View video block class.


### PR DESCRIPTION
Fixes #22 
While working on the new Kitconcept Website, I noticed that there is no Differentiation between Vimeo and Youtube Videos cookie-wise.

I've added said Differentiation in the Video-View, and also added Twitter Conformity for Volto Social Block Support