### PR TITLE
Fix cookie blockers make sites unusable (#30)

### DIFF
--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -145,7 +145,7 @@ const Banner = (props) => {
         open={showConfirmModal}
         dimmer="inverted"
         closeOnDimmerClick={false}
-        className="dsgvo-banner"
+        className="dsgvo-cookie-banner"
       >
         {!configureCookies ? (
           <>


### PR DESCRIPTION
Fixes #30 (I think)

## Steps to "Reproduce"

- install i-don't-care-about-cookies for your browser
- pull changes
- `make start-dev`
- go to localhost:3000
- remove site cookies and reload site

what's happening for me is that the blocker does not block the cookie banner.